### PR TITLE
fix compilation warning

### DIFF
--- a/src/SparkFun_WM8960_Arduino_Library.cpp
+++ b/src/SparkFun_WM8960_Arduino_Library.cpp
@@ -629,7 +629,7 @@ boolean WM8960::setAdcRightDigitalVolumeDB(float dB)
 boolean WM8960::enableAlc(uint8_t mode)
 {
   boolean bit8 = (mode>>1);
-  boolean bit7 = (mode & B00000001);
+  boolean bit7 = (mode & 0b00000001);
   if (WM8960::_writeRegisterBit(WM8960_REG_ALC1, 8, bit8) == 0) return false;
   return WM8960::_writeRegisterBit(WM8960_REG_ALC1, 7, bit7);
 }


### PR DESCRIPTION
Small change for fix compilation warning on esp32 with arduino 3.0.X with -std=gnu++20 flag
```
.pio/libdeps/SparkFun WM8960 Arduino Library/src/SparkFun_WM8960_Arduino_Library.cpp: In member function 'boolean WM8960::enableAlc(uint8_t)':
.pio/libdeps/SparkFun WM8960 Arduino Library/src/SparkFun_WM8960_Arduino_Library.cpp:552:28: warning: 'B00000001' is deprecated: use 0b00000001 instead [-Wdeprecated-declarations]
  552 |     boolean bit7 = (mode & B00000001);
      |                            ^~~~~~~~~
```
