### PR TITLE
VMID setting correction

### DIFF
--- a/src/SparkFun_WM8960_Arduino_Library.cpp
+++ b/src/SparkFun_WM8960_Arduino_Library.cpp
@@ -990,16 +990,29 @@ boolean WM8960::disableRI2MO()
 
 // Enables VMID in the WM8960_REG_PWR_MGMT_2 register, and set's it to 
 // playback/record settings of 2*50Kohm.
+// Note, this function is only hear for backwards compatibility with the
+// original releases of this library. It is recommended to use the
+// setVMID() function instead.
 boolean WM8960::enableVMID()
 {
-  WM8960::_writeRegisterBit(WM8960_REG_PWR_MGMT_1, 8, 1);
-  return WM8960::_writeRegisterBit(WM8960_REG_PWR_MGMT_1, 7, 1);
+  return WM8960::setVMID(WM8960_VMIDSEL_2X50KOHM);
 }
 
 boolean WM8960::disableVMID()
 {
-  WM8960::_writeRegisterBit(WM8960_REG_PWR_MGMT_1, 8, 0);
-  return WM8960::_writeRegisterBit(WM8960_REG_PWR_MGMT_1, 7, 0);
+  return WM8960::setVMID(WM8960_VMIDSEL_DISABLED);
+}
+
+// setVMID
+// Sets the VMID signal to one of three possible settings.
+// 4 options:
+// WM8960_VMIDSEL_DISABLED
+// WM8960_VMIDSEL_2X50KOHM (playback / record)
+// WM8960_VMIDSEL_2X250KOHM (for low power / standby)
+// WM8960_VMIDSEL_2X5KOHM (for fast start-up)
+boolean WM8960::setVMID(uint8_t setting)
+{
+  return WM8960::_writeRegisterMultiBits(WM8960_REG_INPUT_BOOST_MIXER_1, 8, 7, setting);
 }
 
 /////////////////////////////////////////////////////////

--- a/src/SparkFun_WM8960_Arduino_Library.cpp
+++ b/src/SparkFun_WM8960_Arduino_Library.cpp
@@ -1012,7 +1012,7 @@ boolean WM8960::disableVMID()
 // WM8960_VMIDSEL_2X5KOHM (for fast start-up)
 boolean WM8960::setVMID(uint8_t setting)
 {
-  return WM8960::_writeRegisterMultiBits(WM8960_REG_INPUT_BOOST_MIXER_1, 8, 7, setting);
+  return WM8960::_writeRegisterMultiBits(WM8960_REG_PWR_MGMT_1, 8, 7, setting);
 }
 
 /////////////////////////////////////////////////////////

--- a/src/SparkFun_WM8960_Arduino_Library.h
+++ b/src/SparkFun_WM8960_Arduino_Library.h
@@ -298,6 +298,11 @@
 #define WM8960_SPEAKER_BOOST_GAIN_4_5DB 4
 #define WM8960_SPEAKER_BOOST_GAIN_5_1DB 5
 
+// VMIDSEL settings
+#define WM8960_VMIDSEL_DISABLED 0
+#define WM8960_VMIDSEL_2X50KOHM 1
+#define WM8960_VMIDSEL_2X250KOHM 2
+#define WM8960_VMIDSEL_2X5KOHM 3
 
 class WM8960
 {
@@ -613,6 +618,7 @@ class WM8960
 		// playback/record settings of 2*50Kohm.
 		boolean enableVMID(); 
 		boolean disableVMID();
+		boolean setVMID(uint8_t setting = WM8960_VMIDSEL_2X50KOHM);
 
 		/////////////////////////////////////////////////////////
 		///////////////////////////////////////////////////////// Headphones


### PR DESCRIPTION
Fixes issue #1 . 

Note,  for default setting (Playback / Record), use enableVMID()

To specifically set the VMID voltage divider choice, use setVMID()