### PR TITLE
Additional DAC Controls

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -90,6 +90,8 @@ setDacRightDigitalVolumeDB	KEYWORD2
 enableDacMute	KEYWORD2
 disableDacMute	KEYWORD2
 setDacDeEmphasis	KEYWORD2
+enableDacSlopingStopbandFilter	KEYWORD2
+disableDacSlopingStopbandFilter	KEYWORD2
 enable3d	KEYWORD2
 disable3d	KEYWORD2
 set3dDepth	KEYWORD2
@@ -388,7 +390,11 @@ WM8960_VMIDSEL_2X50KOHM	LITERAL1
 WM8960_VMIDSEL_2X250KOHM	LITERAL1
 WM8960_VMIDSEL_2X5KOHM	LITERAL1
 
+WM8960_DEEMPH_NONE	LITERAL1
+WM8960_DEEMPH_32K	LITERAL1
+WM8960_DEEMPH_44_1K	LITERAL1
+WM8960_DEEMPH_48K	LITERAL1
+
 #######################################
 # Instances (KEYWORD3)
 #######################################
-

--- a/keywords.txt
+++ b/keywords.txt
@@ -89,6 +89,7 @@ setDacLeftDigitalVolumeDB	KEYWORD2
 setDacRightDigitalVolumeDB	KEYWORD2	
 enableDacMute	KEYWORD2
 disableDacMute	KEYWORD2
+setDacDeEmphasis	KEYWORD2
 enable3d	KEYWORD2
 disable3d	KEYWORD2
 set3dDepth	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -89,6 +89,10 @@ setDacLeftDigitalVolumeDB	KEYWORD2
 setDacRightDigitalVolumeDB	KEYWORD2	
 enableDacMute	KEYWORD2
 disableDacMute	KEYWORD2
+enableDacSoftMute	KEYWORD2
+disableDacSoftMute	KEYWORD2
+enableDacSlowSoftMute	KEYWORD2
+disableDacSlowSoftMute	KEYWORD2
 setDacDeEmphasis	KEYWORD2
 enableDacSlopingStopbandFilter	KEYWORD2
 disableDacSlopingStopbandFilter	KEYWORD2

--- a/src/SparkFun_WM8960_Arduino_Library.cpp
+++ b/src/SparkFun_WM8960_Arduino_Library.cpp
@@ -806,6 +806,26 @@ boolean WM8960::disableDacMute()
   return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_1, 3, 0);
 }
 
+boolean WM8960::enableDacSoftMute()
+{
+  return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_2, 3, 1);
+}
+
+boolean WM8960::disableDacSoftMute()
+{
+  return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_2, 3, 0);
+}
+
+boolean WM8960::enableDacSlowSoftMute()
+{
+  return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_2, 2, 1);
+}
+
+boolean WM8960::disableDacSlowSoftMute()
+{
+  return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_2, 2, 0);
+}
+
 // DAC De-Emphasis
 boolean WM8960::setDacDeEmphasis(uint8_t setting) {
   return WM8960::_writeRegisterMultiBits(WM8960_REG_ADC_DAC_CTRL_1, 2, 1, setting);

--- a/src/SparkFun_WM8960_Arduino_Library.cpp
+++ b/src/SparkFun_WM8960_Arduino_Library.cpp
@@ -806,6 +806,11 @@ boolean WM8960::disableDacMute()
   return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_1, 3, 0);
 }
 
+// DAC De-Emphasis
+boolean WM8960::setDacDeEmphasis(uint8_t setting) {
+  return WM8960::_writeRegisterMultiBits(WM8960_REG_ADC_DAC_CTRL_1, 2, 1, setting);
+}
+
 // 3D Stereo Enhancement
 // 3D enable/disable
 boolean WM8960::enable3d()

--- a/src/SparkFun_WM8960_Arduino_Library.cpp
+++ b/src/SparkFun_WM8960_Arduino_Library.cpp
@@ -811,6 +811,15 @@ boolean WM8960::setDacDeEmphasis(uint8_t setting) {
   return WM8960::_writeRegisterMultiBits(WM8960_REG_ADC_DAC_CTRL_1, 2, 1, setting);
 }
 
+// DAC Filter
+boolean WM8960::enableDacSlopingStopbandFilter() {
+  return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_2, 1, 1);
+}
+
+boolean WM8960::disableDacSlopingStopbandFilter() {
+  return WM8960::_writeRegisterBit(WM8960_REG_ADC_DAC_CTRL_2, 1, 0);
+}
+
 // 3D Stereo Enhancement
 // 3D enable/disable
 boolean WM8960::enable3d()

--- a/src/SparkFun_WM8960_Arduino_Library.h
+++ b/src/SparkFun_WM8960_Arduino_Library.h
@@ -568,6 +568,10 @@ class WM8960
 		// DAC De-Emphasis
 		boolean setDacDeEmphasis(uint8_t setting);
 
+		// DAC Filter
+		boolean enableDacSlopingStopbandFilter();
+		boolean disableDacSlopingStopbandFilter();
+
 		// 3D Stereo Enhancement
 		// 3D enable/disable
 		boolean enable3d();

--- a/src/SparkFun_WM8960_Arduino_Library.h
+++ b/src/SparkFun_WM8960_Arduino_Library.h
@@ -326,6 +326,12 @@
 #define WM8960_JACKDETECT_LINPUT3 1
 #define WM8960_JACKDETECT_RINPUT3 2
 
+// De-Emphasis settings
+#define WM8960_DEEMPH_NONE 0
+#define WM8960_DEEMPH_32K 1
+#define WM8960_DEEMPH_44_1K 2
+#define WM8960_DEEMPH_48K 3
+
 class WM8960
 {
 	public:
@@ -559,7 +565,8 @@ class WM8960
 		boolean enableDacMute();
 		boolean disableDacMute();
 
-		// DE-Emphasis
+		// DAC De-Emphasis
+		boolean setDacDeEmphasis(uint8_t setting);
 
 		// 3D Stereo Enhancement
 		// 3D enable/disable

--- a/src/SparkFun_WM8960_Arduino_Library.h
+++ b/src/SparkFun_WM8960_Arduino_Library.h
@@ -564,6 +564,10 @@ class WM8960
 		// DAC mute
 		boolean enableDacMute();
 		boolean disableDacMute();
+		boolean enableDacSoftMute();
+		boolean disableDacSoftMute();
+		boolean enableDacSlowSoftMute();
+		boolean disableDacSlowSoftMute();
 
 		// DAC De-Emphasis
 		boolean setDacDeEmphasis(uint8_t setting);


### PR DESCRIPTION
Add the following additional DAC-related controls:

```
enableDacSoftMute
disableDacSoftMute
enableDacSlowSoftMute
disableDacSlowSoftMute
setDacDeEmphasis
enableDacSlopingStopbandFilter
disableDacSlopingStopbandFilter
```

Notes:
- Though the de-emphasis setting is intended for CD audio output, I've found it helpful to clean up the output of Adc signals that have been processed by an MCU and then sent back through the Dac (ie: effects).
- The soft mute settings successfully remove popping noises when `enableDacMute` is called.
- Though, the naming conventions I chose are wordy. Advice on better names for these methods would be appreciated.
- I haven't noticed a significant effect on the output of the Dac with the sloping stopband filter enabled. The science behind these filters is foreign to me, so I'm not positive exactly what benefits there are to gain with this setting. I'd be happy to remove those functions from this PR if it would be preferred to do so in order to avoid confusion.